### PR TITLE
Funny characters in toon names

### DIFF
--- a/lib/battlenet/modules/wow/character_profile.rb
+++ b/lib/battlenet/modules/wow/character_profile.rb
@@ -3,8 +3,8 @@ module Battlenet
     class CharacterProfile < Battlenet::APIResponse
 
       def initialize(options={})
-        @realm          = options.delete(:realm)
-        @character_name = options.delete(:character_name)
+        @realm          = CGI.escape(options.delete(:realm))
+        @character_name = CGI.escape(options.delete(:character_name))
 
         @endpoint       = "/character/#{@realm}/#{@character_name}"
 


### PR DESCRIPTION
this was crashing:

character = client.character_profile({:realm => 'frostmourne', :character_name => 'whispä'})

may as well do for realm name as well?