### PR TITLE
Fix WOW Pet API endpoint

### DIFF
--- a/lib/battlenet/modules/wow/pet.rb
+++ b/lib/battlenet/modules/wow/pet.rb
@@ -3,7 +3,7 @@ module Battlenet
     class Pet < Battlenet::APIResponse
 
       def initialize(options={})
-        @endpoint       = "/wow/pet"
+        @endpoint       = "/pet"
         super(options)
       end
 

--- a/spec/wow/pet_spec.rb
+++ b/spec/wow/pet_spec.rb
@@ -2,6 +2,25 @@ require 'spec_helper'
 
 describe Battlenet::WOW::Pet do
 
+  context "when looking up a species" do
+    before do
+      Battlenet.configure do |config|
+        config.api_key = ENV['BATTLENET_API_KEY']
+        config.region  = :us
+      end
+      @wow_client = Battlenet.WOWClient
+    end
+
+    it "should be able to fetch details" do
+      sid = 1134
+      VCR.use_cassette("pet/species/#{sid}") do
+        species = @wow_client.pet.species(sid)
+        expect(species['speciesId']).to eq(sid)
+        expect(species).to have_key('abilities')
+      end
+    end
+  end
+
   it { should respond_to(:master_list) }
   it { should respond_to(:ability) }
   it { should respond_to(:species) }


### PR DESCRIPTION
Currently the `Pet` API uses a wrong endpoint, which includes the path segment `/wow` twice. This PR fixes the issue and makes the `Pet` API usable again.