### PR TITLE
Add support for multiple clients

### DIFF
--- a/lib/battlenet/api/client.rb
+++ b/lib/battlenet/api/client.rb
@@ -4,62 +4,62 @@ require 'httparty'
 require 'addressable/uri'
 
 module Battlenet
+  class Client
+    attr_accessor *Configuration::OPTIONS_KEYS
 
-    class Client
-      include HTTParty
+    def initialize(options={})
+      options = Battlenet.options.merge(options)
 
-      attr_accessor *Configuration::OPTIONS_KEYS
-
-      def initialize(options={})
-        options = Battlenet.options.merge(options)
-
-        Configuration::OPTIONS_KEYS.each do |key|
-          send("#{key}=", options[key])
-        end
-        self.class.base_uri "https://#{domain}#{endpoint}"
+      Configuration::OPTIONS_KEYS.each do |key|
+        send("#{key}=", options[key])
       end
-
-      def domain
-        domain = case @region
-        when :us
-          'us.api.battle.net'
-        when :eu
-          'eu.api.battle.net'
-        when :kr
-          'kr.api.battle.net'
-        when :tw
-          'tw.api.battle.net'
-        when :cn
-          'api.battlenet.com.cn'
-        else
-          raise "Invalid region: #{region.to_s}"
-        end
-      end
-
-      def endpoint
-          raise "Invalid Game Endpoint" if @endpoint == nil
-          @endpoint
-      end
-
-      def get(path, params = {})
-        make_request :get, path, params
-      end
-
-      def make_request(verb, path, params = {})
-        options = {}
-        headers = {}
-
-        options[:headers] = headers unless headers.empty?
-        options[:query]   = params unless params.empty?
-
-        if @api_key
-          options[:query] ||= {}
-          options[:query].merge!({ :apikey => @api_key })
-        end
-
-        response = self.class.send(verb, Addressable::URI.encode(path), options)
-      end
-
     end
 
+    def base_uri
+      "https://#{domain}#{endpoint}"
+    end
+
+    def domain
+      domain = case @region
+      when :us
+        'us.api.battle.net'
+      when :eu
+        'eu.api.battle.net'
+      when :kr
+        'kr.api.battle.net'
+      when :tw
+        'tw.api.battle.net'
+      when :cn
+        'api.battlenet.com.cn'
+      else
+        raise "Invalid region: #{region.to_s}"
+      end
+    end
+
+    def endpoint
+      raise "Invalid Game Endpoint" if @endpoint == nil
+      @endpoint
+    end
+
+    def get(path, params = {})
+      make_request :get, path, params
+    end
+
+    def make_request(verb, path, params = {})
+      options = {}
+      headers = {}
+
+      options[:headers] = headers unless headers.empty?
+      options[:query]   = params unless params.empty?
+
+      if @api_key
+        options[:query] ||= {}
+        options[:query].merge!({ :apikey => @api_key })
+      end
+
+      encoded_path = Addressable::URI.encode(path)
+
+      response = HTTParty.send(verb, "#{base_uri}#{encoded_path}" , options)
+    end
+  end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -3,12 +3,12 @@ require 'spec_helper'
 describe Battlenet::Client do
   it 'is expected not to override API url when creating multiple clients' do
     eu_client = Battlenet::Client.new(api_key: 'api_key', region: :eu, endpoint: '/wow')
-    expect(eu_client.class.base_uri).to eq 'https://eu.api.battle.net/wow'
+    expect(eu_client.base_uri).to eq 'https://eu.api.battle.net/wow'
 
     us_client = Battlenet::Client.new(api_key: 'api_key', region: :us, endpoint: '/wow')
-    expect(us_client.class.base_uri).to eq 'https://us.api.battle.net/wow'
+    expect(us_client.base_uri).to eq 'https://us.api.battle.net/wow'
 
-    expect(eu_client.class.base_uri).to eq 'https://eu.api.battle.net/wow'
+    expect(eu_client.base_uri).to eq 'https://eu.api.battle.net/wow'
   end
 
   # it "should translate foreign characters for URLS (whispä)" do

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,13 +1,14 @@
 require 'spec_helper'
 
 describe Battlenet::Client do
+  it 'is expected not to override API url when creating multiple clients' do
+    eu_client = Battlenet::Client.new(api_key: 'api_key', region: :eu, endpoint: '/wow')
+    expect(eu_client.class.base_uri).to eq 'https://eu.api.battle.net/wow'
 
-  before do
-    Battlenet.configure do |config|
-      config.api_key = ENV['BATTLENET_API_KEY']
-      config.region  = :us
-    end
-    @client = Battlenet::Client.new
+    us_client = Battlenet::Client.new(api_key: 'api_key', region: :us, endpoint: '/wow')
+    expect(us_client.class.base_uri).to eq 'https://us.api.battle.net/wow'
+
+    expect(eu_client.class.base_uri).to eq 'https://eu.api.battle.net/wow'
   end
 
   # it "should translate foreign characters for URLS (whispä)" do
@@ -17,5 +18,4 @@ describe Battlenet::Client do
   # it "should translate spaces accurately for URLS (emerald dream)" do
   #   character = @client.character({:realm => 'emerald dream', :character_name => 'pftpft'})
   # end
-
 end


### PR DESCRIPTION
Currently, due to implementation detail around `Battlenet::Client` and its use of `HTTParty`, there is a bug that makes working with multiple clients impossible. Because the client class extends `HTTParty` and the constructor sets the URL value on the class itself, the last instantiated client will override the URL for all other clients. This is unintended behaviour.

This PR solves that issue by moving `base_uri` from the class to the instance and invoking requests through `HTTParty` directly. The first commit provides a failing spec based on the current implementation and the second commit includes the fix with the modified spec.